### PR TITLE
Added monthStylePredicate to custom month button colors

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -69,6 +69,30 @@ class _MyAppState extends State<MyApp> {
                 locale: const Locale('en'),
                 //show only even months
                 selectableMonthPredicate: (DateTime val) => val.month.isEven,
+                monthStylePredicate: (DateTime val) {
+                  if (val.month == 4) {
+                    return TextButton.styleFrom(
+                      backgroundColor: Colors.blue,
+                      textStyle: TextStyle(
+                        color: Colors.black,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    );
+                  }
+                  return null;
+                },
+                yearStylePredicate: (int val) {
+                  if (val == 2022) {
+                    return TextButton.styleFrom(
+                      backgroundColor: Colors.blue,
+                      textStyle: TextStyle(
+                        color: Colors.black,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    );
+                  }
+                  return null;
+                },
                 headerColor: Colors.amber[900],
                 headerTextColor: Colors.black,
                 selectedMonthBackgroundColor: Colors.amber[900],
@@ -90,7 +114,7 @@ class _MyAppState extends State<MyApp> {
                 ),
                 roundedCornersRadius: 20,
                 yearFirst: true,
-                backgroundColor: Colors.yellow[100]
+                backgroundColor: Colors.yellow[100],
                 //forceSelectedDate: true,
                 //dismissible: true,
                 // capitalizeFirstLetter: true,

--- a/lib/month_picker_dialog.dart
+++ b/lib/month_picker_dialog.dart
@@ -19,6 +19,10 @@ import 'src/year_selector/year_selector.dart';
 ///
 /// [selectableMonthPredicate] lets you control enabled months just like the official selectableDayPredicate.
 ///
+/// [monthStylePredicate] allows you to individually customize each month.
+///
+/// [yearStylePredicate] allows you to individually customize each year.
+///
 /// [capitalizeFirstLetter] lets you control if your months names are capitalized or not.
 ///
 /// [headerColor] lets you control the calendar header color.
@@ -54,6 +58,8 @@ Future<DateTime?> showMonthPicker({
   DateTime? lastDate,
   Locale? locale,
   bool Function(DateTime)? selectableMonthPredicate,
+  ButtonStyle? Function(DateTime)? monthStylePredicate,
+  ButtonStyle? Function(int)? yearStylePredicate,
   bool capitalizeFirstLetter = true,
   Color? headerColor,
   Color? headerTextColor,
@@ -78,6 +84,8 @@ Future<DateTime?> showMonthPicker({
     lastDate: lastDate,
     locale: locale,
     selectableMonthPredicate: selectableMonthPredicate,
+    monthStylePredicate: monthStylePredicate,
+    yearStylePredicate: yearStylePredicate,
     capitalizeFirstLetter: capitalizeFirstLetter,
     headerColor: headerColor,
     headerTextColor: headerTextColor,

--- a/lib/src/helpers/controller.dart
+++ b/lib/src/helpers/controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 import '/src/helpers/extensions.dart';
@@ -11,6 +12,8 @@ class MonthpickerController {
     this.lastDate,
     this.locale,
     this.selectableMonthPredicate,
+    this.monthStylePredicate,
+    this.yearStylePredicate,
     required this.capitalizeFirstLetter,
     this.headerColor,
     this.headerTextColor,
@@ -31,6 +34,8 @@ class MonthpickerController {
   final DateTime? firstDate, lastDate, initialDate;
   final Locale? locale;
   final bool Function(DateTime)? selectableMonthPredicate;
+  final ButtonStyle? Function(DateTime)? monthStylePredicate;
+  final ButtonStyle? Function(int)? yearStylePredicate;
   final bool capitalizeFirstLetter, yearFirst, forceSelectedDate;
   final Color? headerColor,
       headerTextColor,

--- a/lib/src/month_selector/month_button.dart
+++ b/lib/src/month_selector/month_button.dart
@@ -47,29 +47,35 @@ class MonthButton extends StatelessWidget {
     final bool isEnabled = _isEnabled(date);
     final Color backgroundColor =
         controller.selectedMonthBackgroundColor ?? theme.colorScheme.secondary;
+    ButtonStyle monthStyle = TextButton.styleFrom(
+      foregroundColor: date.month == controller.selectedDate.month &&
+              date.year == controller.selectedDate.year
+          ? theme.textTheme.labelLarge!
+              .copyWith(
+                color: controller.selectedMonthTextColor ??
+                    theme.colorScheme.onSecondary,
+              )
+              .color
+          : date.month == DateTime.now().month &&
+                  date.year == DateTime.now().year
+              ? backgroundColor
+              : controller.unselectedMonthTextColor,
+      backgroundColor: date.month == controller.selectedDate.month &&
+              date.year == controller.selectedDate.year
+          ? backgroundColor
+          : null,
+      shape: const CircleBorder(),
+    );
+
+    if (controller.monthStylePredicate != null) {
+      monthStyle = monthStyle.merge(controller.monthStylePredicate!(date));
+    }
+
     return TextButton(
       onPressed: isEnabled
           ? () => onMonthSelected(DateTime(date.year, date.month))
           : null,
-      style: TextButton.styleFrom(
-        foregroundColor: date.month == controller.selectedDate.month &&
-                date.year == controller.selectedDate.year
-            ? theme.textTheme.labelLarge!
-                .copyWith(
-                  color: controller.selectedMonthTextColor ??
-                      theme.colorScheme.onSecondary,
-                )
-                .color
-            : date.month == DateTime.now().month &&
-                    date.year == DateTime.now().year
-                ? backgroundColor
-                : controller.unselectedMonthTextColor,
-        backgroundColor: date.month == controller.selectedDate.month &&
-                date.year == controller.selectedDate.year
-            ? backgroundColor
-            : null,
-        shape: const CircleBorder(),
-      ),
+      style: monthStyle,
       child: Text(
         controller.capitalizeFirstLetter
             ? toBeginningOfSentenceCase(

--- a/lib/src/year_selector/year_button.dart
+++ b/lib/src/year_selector/year_button.dart
@@ -50,22 +50,29 @@ class YearButton extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final Color backgroundColor =
         controller.selectedMonthBackgroundColor ?? theme.colorScheme.secondary;
+    ButtonStyle yearStyle = TextButton.styleFrom(
+      foregroundColor: year == controller.selectedDate.year
+          ? theme.textTheme.labelLarge!
+              .copyWith(
+                color: controller.selectedMonthTextColor ??
+                    theme.colorScheme.onSecondary,
+              )
+              .color
+          : year == DateTime.now().year
+              ? backgroundColor
+              : controller.unselectedMonthTextColor,
+      backgroundColor:
+          year == controller.selectedDate.year ? backgroundColor : null,
+      shape: const CircleBorder(),
+    );
+
+    if (controller.yearStylePredicate != null) {
+      yearStyle = yearStyle.merge(controller.yearStylePredicate!(year));
+    }
+
     return TextButton(
       onPressed: isEnabled ? () => onYearSelected(year) : null,
-      style: TextButton.styleFrom(
-          foregroundColor: year == controller.selectedDate.year
-              ? theme.textTheme.labelLarge!
-                  .copyWith(
-                    color: controller.selectedMonthTextColor ??
-                        theme.colorScheme.onSecondary,
-                  )
-                  .color
-              : year == DateTime.now().year
-                  ? backgroundColor
-                  : controller.unselectedMonthTextColor,
-          backgroundColor:
-              year == controller.selectedDate.year ? backgroundColor : null,
-          shape: const CircleBorder()),
+      style: yearStyle,
       child: Text(
         DateFormat.y(localeString).format(DateTime(year)),
       ),


### PR DESCRIPTION
- This change allows you to pass a different style for each month or year

![image](https://user-images.githubusercontent.com/19338037/232149389-3431aacf-9081-44cb-9a5c-dcd6024efe07.png)
![image](https://user-images.githubusercontent.com/19338037/232149410-4cabef36-89b9-45b6-aedf-6511fc782fef.png)

The same pattern as the `selectableMonthPredicate `method was followed, and its use is also very simple, follow the examples:

1 - Change April color for blue;
```dart
    monthStylePredicate: (DateTime val) {
      if (val.month == 4) {
        return TextButton.styleFrom(
          backgroundColor: Colors.blue,
          textStyle: TextStyle(
            color: Colors.black,
            fontWeight: FontWeight.bold,
          ),
        );
      }
      return null;
    }
```
2 - Change only 2022 color for blue;
```dart
    yearStylePredicate: (int val) {
      if (val == 2022) {
        return TextButton.styleFrom(
          backgroundColor: Colors.blue,
          textStyle: TextStyle(
            color: Colors.black,
            fontWeight: FontWeight.bold,
          ),
        );
      }
      return null;
    }
```